### PR TITLE
refactor: videoSection의 역할을 동적으로 할당하는 기능을 추가 

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -36,6 +36,7 @@ function App() {
             }
             scrollY={scrollY}
             index={0}
+            totalSections={3}
           />
           <VideoSection
             videoSrc={section1}
@@ -47,6 +48,7 @@ function App() {
             }
             scrollY={scrollY}
             index={1}
+            totalSections={3}
           />
           <VideoSection
             videoSrc={section2}
@@ -58,7 +60,8 @@ function App() {
               </>
             }
             scrollY={scrollY}
-            index={1}
+            index={2}
+            totalSections={3}
           />
         </div>
       </div>

--- a/src/videoSection.js
+++ b/src/videoSection.js
@@ -35,7 +35,7 @@ const VideoSection = ({ videoSrc, text, scrollY, index, totalSections }) => {
       : Math.min(scrollY / 5 + 100, 150);
 
   let translateY = 0;
-  const transitionPoint = window.innerHeight * 0.7;
+  const transitionPoint = window.innerHeight * 0.77;
   const transitionOffset = transitionPoint / 3;
 
   if (index === 0) {
@@ -71,7 +71,13 @@ const VideoSection = ({ videoSrc, text, scrollY, index, totalSections }) => {
       >
         <source src={videoSrc} type="video/mp4" />
       </video>
-      <div className={`videoText ${showText ? "fadeIn" : ""}`} ref={textRef}>
+      <div
+        className={`videoText ${showText ? "fadeIn" : ""}`}
+        ref={textRef}
+        style={{
+          transform: `translate(-50%, -50%) translateY(${translateY}px)`, //비디오 동기화
+        }}
+      >
         {text}
       </div>
     </div>

--- a/src/videoSection.js
+++ b/src/videoSection.js
@@ -1,68 +1,65 @@
 import React, { useRef, useEffect, useState } from "react";
 import PropTypes from "prop-types";
 
-const VideoSection = ({ videoSrc, text, scrollY, index }) => {
+const VideoSection = ({ videoSrc, text, scrollY, index, totalSections }) => {
   const [showText, setShowText] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
   const textRef = useRef(null);
 
-  // 화면 크기 상태 추가
-  const [isMobile, setIsMobile] = useState(false);
+  const handleResize = () => {
+    setIsMobile(window.innerWidth <= 768);
+  };
 
   useEffect(() => {
-    // 화면 크기 확인
-    const handleResize = () => {
-      if (window.innerWidth <= 768) {
-        setIsMobile(true); // 모바일 화면일 때
-      } else {
-        setIsMobile(false); // 모바일 화면이 아닐 때
-      }
-    };
-
-    handleResize(); // 초기 화면 크기 확인
-    window.addEventListener("resize", handleResize); // 화면 크기 변경 시 이벤트 리스너 추가
-
-    return () => window.removeEventListener("resize", handleResize); // 이벤트 리스너 정리
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
   }, []);
 
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            setShowText(true);
-          } else {
-            setShowText(false);
-          }
-        });
+        entries.forEach((entry) => setShowText(entry.isIntersecting));
       },
       { threshold: 0.6 }
     );
 
-    if (textRef.current) {
-      observer.observe(textRef.current);
-    }
-
-    return () => {
-      if (textRef.current) {
-        observer.unobserve(textRef.current);
-      }
-    };
+    if (textRef.current) observer.observe(textRef.current);
+    return () => observer.disconnect();
   }, []);
 
-  // 모바일 여부에 따른 비디오 높이 계산
-  const videoHeight =
-    index === 0
+  const videoHeight = isMobile
+    ? Math.min(scrollY / 5 + 100, 100)
+    : index === 0
       ? Math.max(100 - scrollY / 5, 0)
-      : isMobile
-        ? Math.min(scrollY / 5 + 100, 100) // 모바일에서는 100vh
-        : Math.min(scrollY / 5 + 100, 150); // 나머지에서는 150vh
+      : Math.min(scrollY / 5 + 100, 150);
 
-  const translateY = index === 0 ? scrollY / 3 : -scrollY / 3;
+  let translateY = 0;
+  const transitionPoint = window.innerHeight * 0.7;
+  const transitionOffset = transitionPoint / 3;
+
+  if (index === 0) {
+    translateY = scrollY / 3;
+  } else if (index === totalSections - 1) {
+    translateY = -scrollY / 3;
+  } else {
+    if (scrollY < transitionPoint) {
+      translateY = -scrollY / 3;
+    } else {
+      translateY = (scrollY - transitionPoint) / 3 - transitionOffset;
+    }
+  }
 
   return (
     <div className="videoWrapper">
       <video
-        className={index === 0 ? "topVideo" : "bottomVideo"}
+        className={
+          index === 0
+            ? "topVideo"
+            : index === totalSections - 1
+              ? "bottomVideo"
+              : "middleVideo"
+        }
         style={{
           height: `${videoHeight}vh`,
           transform: `translateY(${translateY}px)`,
@@ -70,7 +67,7 @@ const VideoSection = ({ videoSrc, text, scrollY, index }) => {
         autoPlay
         muted
         loop
-        playsInline // 모바일에서 전체화면 전환을 방지
+        playsInline
       >
         <source src={videoSrc} type="video/mp4" />
       </video>
@@ -86,6 +83,7 @@ VideoSection.propTypes = {
   text: PropTypes.node.isRequired,
   scrollY: PropTypes.number.isRequired,
   index: PropTypes.number.isRequired,
+  totalSections: PropTypes.number.isRequired,
 };
 
 export default VideoSection;

--- a/src/videoSection.js
+++ b/src/videoSection.js
@@ -35,7 +35,10 @@ const VideoSection = ({ videoSrc, text, scrollY, index, totalSections }) => {
       : Math.min(scrollY / 5 + 100, 150);
 
   let translateY = 0;
-  const transitionPoint = window.innerHeight * 0.77;
+  const transitionPoint = isMobile
+    ? window.innerHeight * 0.77 // 0.77은 모바일규격일시
+    : window.innerHeight * 0.2;
+
   const transitionOffset = transitionPoint / 3;
 
   if (index === 0) {
@@ -63,6 +66,8 @@ const VideoSection = ({ videoSrc, text, scrollY, index, totalSections }) => {
         style={{
           height: `${videoHeight}vh`,
           transform: `translateY(${translateY}px)`,
+          width: "100%", // 화면 너비에 맞게 비디오 넓이 조정
+          objectFit: "cover", // 비디오가 화면을 가득 채우게 설정
         }}
         autoPlay
         muted


### PR DESCRIPTION
## 작업내용
- resolves #13 
- 어떻게 해결 ?

```
if (index === 0) {
    translateY = scrollY / 3;
  } else if (index === totalSections - 1) {
    translateY = -scrollY / 3;
  } else {
    if (scrollY < transitionPoint) {
      translateY = -scrollY / 3;
    } else {
      translateY = (scrollY - transitionPoint) / 3 - transitionOffset;
    }
  }
```

else 문에서 중간 비디오의 역할을 지정해주는데, transitionPoint기준으로 변동을 시켜줬다
모바일과, 데스크탑에서 적절한 비율을 찾아서 지정해주었다.

## 추가작업 
- 비디오 텍스트 height 동기화
- 반응형 처리 

## transitionOffset의 도입
- 며칠동안 가장 이 문제를 해결하기 어려웠던 점이 무엇이냐면, 
- 인덱스 값이 달라지면서 중간비디오의 역할이 달라질 때 화면상에서 위치가 변동이 되는 현상 때문에
- 정말 많은 고민을 했는데 transitionOffset을 도입해서 해결을 했다.

